### PR TITLE
Fix Venti bug, added test and an extra message

### DIFF
--- a/src/components/modal.jsx
+++ b/src/components/modal.jsx
@@ -33,6 +33,10 @@ export default function Modal(props) {
           <p>
             All product names, logos, and brands are property of their respective owners in the United States and/or other countries.
           </p>
+          <p className="font-weight-bold">
+            Please be warned that this tool is not guaranteed to reflect your true gacha experience. 
+            You might earn a 5 star here, but not in Genshin Impact, and in reverse. Use this tool with responsibility!
+          </p>
         </div>
       </div>
     </div>

--- a/src/models/ballad-in-goblets.js
+++ b/src/models/ballad-in-goblets.js
@@ -42,8 +42,22 @@ export default class BalladInGoblets extends BaseGacha {
     return this.probabilityRange[this.generateRandomNumber(this.probabilityRange.length)]
   }
   getRandomItem(rating) {
-    const itemsList = this.getDrops(rating)
-    const item = itemsList[this.generateRandomNumber(itemsList.length)]
+    const itemsList = this.getDrops(rating);
+    let item;
+
+    // If our previous SSR didn't drop a Venti, then this time, we'll get him.
+    if (this.guaranteedVenti && rating === 5) {
+      item = this.drops.find((el) => el.name === 'Venti');
+      this.guaranteedVenti = false;
+    } else {
+      item = itemsList[this.generateRandomNumber(itemsList.length)];
+    }
+
+    // This is a checker to check if our current pull does not contain a Venti.
+    if (item.rating === 5 && item.name !== 'Venti') {
+      this.guaranteedVenti = true;
+    }
+
     return item
   }
   getGuaranteed5StarItem() {
@@ -51,7 +65,6 @@ export default class BalladInGoblets extends BaseGacha {
     if(this.guaranteedVenti || isVenti) {
       return this.grabAVenti()
     }
-    this.guaranteedVenti = true
     return this.getRandomItem(5)
   }
   getGuaranteed4StarItemOrHigher() {

--- a/src/models/ballad-in-goblets.js
+++ b/src/models/ballad-in-goblets.js
@@ -47,8 +47,7 @@ export default class BalladInGoblets extends BaseGacha {
 
     // If our previous SSR didn't drop a Venti, then this time, we'll get him.
     if (this.guaranteedVenti && rating === 5) {
-      item = this.drops.find((el) => el.name === 'Venti');
-      this.guaranteedVenti = false;
+      return this.grabAVenti();
     } else {
       item = itemsList[this.generateRandomNumber(itemsList.length)];
     }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 const chai = require('chai')
 const { expect } = chai
-import { assert } from 'chai'
 import BalladInGoblets from '../src/models/ballad-in-goblets'
 import BeginnersWish from '../src/models/beginners-wish'
 import EpitomeInvocation from '../src/models/epitome-invocation'
@@ -92,18 +91,19 @@ describe('Testing suite for genshin impact gacha', () => {
 
       // Infinite loop, we want to keep pulling until we discovered a Venti.
       while (true) {
-        results.push(balladVenti.roll());
+        const roll = balladVenti.roll();
+        results.push(roll);
         
         // Filter all the results by its five star.
         // If there are any results, store its name in a new array for easier checking.
-        const filteredResults = results[results.length - 1].filter((item) => item.rating === 5);
-        const names = filteredResults.map((e) => e.name);
-        const areNamesFilled = names.length > 0 ? true : false;
+        const filteredResults = results[results.length - 1].filter(item => item.rating === 5);
+        const names = filteredResults.map(e => e.name);
+        const areNamesFilled = names.length > 0;
         
         // This step will fail if the second SSR is not Venti.
         // We'll also have to check if we pulled any SSR, hence the 'names.length' to prevent false negatives.
         if (hasSSR && !names.includes('Venti') && areNamesFilled) {
-          assert.fail('The second SSR pulled was not Venti!');
+          expect.fail('The second SSR pulled was not Venti!');
         }
 
         // If the first SSR is not Venti, set 'hasSSR' to true.

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 const chai = require('chai')
 const { expect } = chai
+import { assert } from 'chai'
 import BalladInGoblets from '../src/models/ballad-in-goblets'
 import BeginnersWish from '../src/models/beginners-wish'
 import EpitomeInvocation from '../src/models/epitome-invocation'
@@ -75,6 +76,49 @@ describe('Testing suite for genshin impact gacha', () => {
 
         // Then, if we get Venti in less than 180 pulls, set 'hasVenti' to true and exit the loop.
         if (results[i].find((item) => item.rating === 5 && item.name === 'Venti')) {
+          hasVenti = true;
+          break;
+        }
+      }
+
+      expect(hasVenti).to.be.true;
+      done();
+    })
+    it('should give a Venti after pulling an SSR that is not Venti (first Venti pull is also acceptable)', done => {
+      const results = [];
+      const balladVenti = new BalladInGoblets();
+      let hasVenti = false;
+      let hasSSR = false;
+
+      // Infinite loop, we want to keep pulling until we discovered a Venti.
+      while (true) {
+        results.push(balladVenti.roll());
+        
+        // Filter all the results by its five star.
+        // If there are any results, store its name in a new array for easier checking.
+        const filteredResults = results[results.length - 1].filter((item) => item.rating === 5);
+        const names = filteredResults.map((e) => e.name);
+        const areNamesFilled = names.length > 0 ? true : false;
+        
+        // This step will fail if the second SSR is not Venti.
+        // We'll also have to check if we pulled any SSR, hence the 'names.length' to prevent false negatives.
+        if (hasSSR && !names.includes('Venti') && areNamesFilled) {
+          assert.fail('The second SSR pulled was not Venti!');
+        }
+
+        // If the first SSR is not Venti, set 'hasSSR' to true.
+        if (!names.includes('Venti') && areNamesFilled) {
+          hasSSR = true;
+        }
+
+        // The next SSR, we have to check if it is truly Venti.
+        if (hasSSR && names.includes('Venti') && areNamesFilled) {
+          hasVenti = true;
+          break;
+        }
+
+        // If the SSR is Venti, then exit.
+        if (names.includes('Venti') && areNamesFilled) {
           hasVenti = true;
           break;
         }

--- a/test/test.js
+++ b/test/test.js
@@ -96,7 +96,7 @@ describe('Testing suite for genshin impact gacha', () => {
         
         // Filter all the results by its five star.
         // If there are any results, store its name in a new array for easier checking.
-        const filteredResults = results[results.length - 1].filter(item => item.rating === 5);
+        const filteredResults = roll.filter(item => item.rating === 5);
         const names = filteredResults.map(e => e.name);
         const areNamesFilled = names.length > 0;
         


### PR DESCRIPTION
Hello!

This PR addresses the following:
- I have fixed the Venti bug. We should now properly get him if our first SSR is not Venti.
- Also added test suite for the guaranteed SSR after a non-Venti SSR pull.
- Added an additional disclaimer message on the modal that people should not expect this tool to be the reflection of their gacha experience, as some people are simply hopeless and believed that if they got an SSR here, then they would also get them in the game as well 😂 (even I sometimes hope so every time I get an SSR from the gacha simulator!).

Oh, and I think I found a bug:
- When we receive an SSR that is not from the 90 pull, I believe the `attemptsCount` variable is not reset to zero, which is the expected behavior from Genshin Impact's gacha. In other words, because of this bug, we are guaranteed to get an SSR every 90 `attemptsCount`, even if we had gained one SSR beforehand.
- But I also notice that you use the `attemptsCount` variable to take note about how much times we have pulled. I propose a fix and that is to create a new variable to store how many times we have pulled from the gacha pool, but it will be reset every time we pulled an SSR. 

Here is an example of the bug. As you can see, I have fixed it so the second SSR is Venti. However, if I tested it many times and added a `console.log` to print the drops to the screen, an SSR is always on the 90th pull, even if we had gained one SSR beforehand (please ignore the `true` and `false`, it's just I printed it to the console so I can see the variable values for easier debugging).
<img width="344" alt="Capture4" src="https://user-images.githubusercontent.com/31909304/96406284-4bc2df00-1209-11eb-8598-bade774e0195.PNG">

I think I can fix that if you want, what do you think? I'll make another issue and another pull request, as they say that smaller PR's are better 😅.

Thank you very much!

Resolves #2 