### PR TITLE
Data for Klee's gacha

### DIFF
--- a/src/data/sparkling-steps.json
+++ b/src/data/sparkling-steps.json
@@ -1,0 +1,359 @@
+[
+  {
+    "name": "Klee",
+    "element": "Pyro",
+    "type": "character",
+    "rating": 5,
+    "id": "749031404964151376",
+    "isFeatured": true,
+    "src": "Klee.png"
+  },
+  {
+    "name": "Keqing",
+    "element": "Electro",
+    "type": "character",
+    "rating": 5,
+    "id": "749031397896749127",
+    "src": "Keqing.png"
+  },
+  {
+    "name": "Mona",
+    "element": "Hydro",
+    "type": "character",
+    "rating": 5,
+    "id": "749031417895452754",
+    "src": "Mona.png"
+  },
+  {
+    "name": "Qiqi",
+    "element": "Cryo",
+    "type": "character",
+    "rating": 5,
+    "id": "749031442494914661",
+    "src": "Qiqi.png"
+  },
+  {
+    "name": "Diluc",
+    "element": "Pyro",
+    "type": "character",
+    "rating": 5,
+    "id": "749031368255602861",
+    "src": "Diluc.png"
+  },
+  {
+    "name": "Jean",
+    "element": "Anemo",
+    "type": "character",
+    "rating": 5,
+    "id": "749031380716879922",
+    "src": "Jean.png"
+  },
+  {
+    "name": "Sucrose",
+    "element": "Anemo",
+    "type": "character",
+    "rating": 4,
+    "id": "749031457019658401",
+    "isFeatured": true,
+    "src": "Sucrose.png"
+  },
+  {
+    "name": "Noelle",
+    "element": "Geo",
+    "type": "character",
+    "rating": 4,
+    "id": "749031431132545057",
+    "isFeatured": true,
+    "src": "Noelle.png"
+  },
+  {
+    "name": "Xingqiu",
+    "element": "Hydro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031483263680563",
+    "isFeatured": true,
+    "src": "Xingqiu.png"
+  },
+  {
+    "name": "Chongyun",
+    "element": "Cryo",
+    "type": "character",
+    "rating": 4,
+    "id": "749031361934917682",
+    "src": "Chongyun.png"
+  },
+  {
+    "name": "Bennett",
+    "element": "Pyro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031351533043772",
+    "src": "Bennett.png"
+  },
+  {
+    "name": "Fischl",
+    "element": "Electro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031374052393120",
+    "src": "Fischl.png"
+  },
+  {
+    "name": "Ningguang",
+    "element": "Electro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031423905759253",
+    "src": "Ningguang.png"
+  },
+  {
+    "name": "Beidou",
+    "element": "Electro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031334273613904",
+    "src": "Beidou.png"
+  },
+  {
+    "name": "Xiangling",
+    "element": "Pyro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031470726905977",
+    "src": "Xiangling.png"
+  },
+  {
+    "name": "Razor",
+    "element": "Electro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031449864306719",
+    "src": "Razor.png"
+  },
+  {
+    "name": "Barbara",
+    "element": "Hydro",
+    "type": "character",
+    "rating": 4,
+    "id": "749031327726174398",
+    "src": "Barbara.png"
+  },
+  {
+    "name": "Rust",
+    "rating": 4,
+    "class": "Bow",
+    "type": "weapon",
+    "src": "rust.png"
+  },
+  {
+    "name": "Sacrificial Bow",
+    "rating": 4,
+    "class": "Bow",
+    "type": "weapon",
+    "src": "sacrificial-bow.png"
+  },
+  {
+    "name": "The Stringless",
+    "rating": 4,
+    "class": "Bow",
+    "type": "weapon",
+    "src": "the-stringless.png"
+  },
+  {
+    "name": "Favonius Warbow",
+    "rating": 4,
+    "class": "Bow",
+    "type": "weapon",
+    "src": "favonius-warbow.png"
+  },
+  {
+    "name": "Eye of Perception",
+    "rating": 4,
+    "class": "Catalyst",
+    "type": "weapon",
+    "src": "eye-of-perception.png"
+  },
+  {
+    "name": "Sacrificial Fragments",
+    "rating": 4,
+    "class": "Catalyst",
+    "type": "weapon",
+    "src": "sacrificial-fragments.png"
+  },
+  {
+    "name": "The Widsith",
+    "rating": 4,
+    "class": "Catalyst",
+    "type": "weapon",
+    "src": "the-widsith.png"
+  },
+  {
+    "name": "Favonius Codex",
+    "rating": 4,
+    "class": "Catalyst",
+    "type": "weapon",
+    "src": "favonius-codex.png"
+  },
+  {
+    "name": "Favonius Lance",
+    "rating": 4,
+    "class": "Lance",
+    "type": "weapon",
+    "src": "favonius-lance.png"
+  },
+  {
+    "name": "Dragon's Bane",
+    "rating": 4,
+    "class": "Polearm",
+    "type": "weapon",
+    "src": "dragons-bane.png"
+  },
+  {
+    "name": "Rainslasher",
+    "rating": 4,
+    "class": "Claymore",
+    "type": "weapon",
+    "src": "rainslasher.png"
+  },
+  {
+    "name": "Sacrificial Greatsword",
+    "rating": 4,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "sacrificial-greatsword.png"
+  },
+  {
+    "name": "The Bell",
+    "rating": 4,
+    "class": "Claymore",
+    "type": "weapon",
+    "src": "the-bell.png"
+  },
+  {
+    "name": "Favonius Greatsword",
+    "rating": 4,
+    "class": "Claymore",
+    "type": "weapon",
+    "src": "favonius-greatsword.png"
+  },
+  {
+    "name": "Lions Roar",
+    "rating": 4,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "lions-roar.png"
+  },
+  {
+    "name": "Sacrificial Sword",
+    "rating": 4,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "sacrificial-sword.png"
+  },
+  {
+    "name": "The Flute",
+    "rating": 4,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "the-flute.png"
+  },
+  {
+    "name": "Favonius Sword",
+    "rating": 4,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "favonius-sword.png"
+  },
+  {
+    "name": "Slingshot",
+    "rating": 3,
+    "class": "Bow",
+    "type": "weapon",
+    "src": "slingshot.png"
+  },
+  {
+    "name": "Sharpshooter's Oath",
+    "rating": 3,
+    "class": "Bow",
+    "type": "weapon",
+    "src": "sharpshooters-oath.png"
+  },
+  {
+    "name": "Raven Bow",
+    "rating": 3,
+    "class": "Bow",
+    "type": "weapon",
+    "src": "raven-bow.png"
+  },
+  {
+    "name": "Emerald Orb",
+    "rating": 3,
+    "class": "Catalyst",
+    "type": "weapon",
+    "src": "emerald-orb.png"
+  },
+  {
+    "name": "Thrilling Tales of Dragon Slayers",
+    "rating": 3,
+    "class": "Catalyst",
+    "type": "weapon",
+    "src": "thrilling-tales-of-dragon-slayers.png"
+  },
+  {
+    "name": "Magic Guide",
+    "rating": 3,
+    "class": "Catalyst",
+    "type": "weapon",
+    "src": "magic-guide.png"
+  },
+  {
+    "name": "Black Tassel",
+    "rating": 3,
+    "class": "Polearm",
+    "type": "weapon",
+    "src": "black-tassel.png"
+  },
+  {
+    "name": "Debate Club",
+    "rating": 3,
+    "class": "Claymore",
+    "type": "weapon",
+    "src": "debate-club.png"
+  },
+  {
+    "name": "Bloodtainted Greatsword",
+    "rating": 3,
+    "class": "Claymore",
+    "type": "weapon",
+    "src": "bloodtainted-greatsword.png"
+  },
+  {
+    "name": "Ferrous Shadow",
+    "rating": 3,
+    "class": "Claymore",
+    "type": "weapon",
+    "src": "ferrous-shadow.png"
+  },
+  {
+    "name": "Skyrider Sword",
+    "rating": 3,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "skyrider-sword.png"
+  },
+  {
+    "name": "Harbinger of Dawn",
+    "rating": 3,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "harbinger-of-dawn.png"
+  },
+  {
+    "name": "Cool Steel",
+    "rating": 3,
+    "class": "Sword",
+    "type": "weapon",
+    "src": "cool-steel.png"
+  }
+]


### PR DESCRIPTION
This PR adds data in the `src/data/sparkling-steps.json` for Klee's banner. I have seen the lineups and decided to add them here. Still no luck getting Klee though 🤣. I thought about adding images and things like that, but I believe the other contributor wants to add them himself? (@NathanPang001)

I have a question. Aside from Klee, it appears that the weapon banner for this period is also called 'Epitome Invocation'. I thought about replacing the previous data in `src/data/epitome-invocation.json` with the new data from the current 'Epitome Invocation', but I believe it is better if I asked you first. What do you think? Should I replace the data from the old file or should I create a new file?

Oh, and would you like me to add the views or the model for the Klee banner? Or would you like to add them yourself?

Either way, thank you!