### PR TITLE
Reset banner bug fix

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -77,7 +77,7 @@ export default class App extends Component {
     }
     this.setState({inventory, currentWishes: []}, this.saveData)
   }
-  reset() {
+  reset(previouslySelectedWish) {
     this.beginnersWish.attemptsCount = 0
     this.beginnersWish.guaranteedNoelle = true
     this.sparklingSteps.attemptsCount = 0
@@ -85,7 +85,7 @@ export default class App extends Component {
     this.epitomeInvocation.attemptsCount = 0
     this.setState({
       isBeginnersWishLimited: false,
-      currentDetails: 'beginners-wish',
+      selectedWish: previouslySelectedWish,
       inventory: {}
     }, this.saveData)
   }

--- a/src/components/banners.jsx
+++ b/src/components/banners.jsx
@@ -60,7 +60,6 @@ export default class Banners extends Component {
       })
     } else {
       this.setState({
-        selectedBanner: 'beginners-wish',
         banners: {
           'beginners-wish': 'Novice Wishes',
           'sparkling-steps': 'Character Event Wish',
@@ -157,7 +156,9 @@ export default class Banners extends Component {
                 Wish x10
               </div>
               <div
-                onClick={reset}
+                onClick={() => {
+                  reset(selectedBanner);
+                }}
                 className="wish-button"
                 >Reset</div>
             </div>


### PR DESCRIPTION
Hello!

This PR fixes the bug as explained in issue #17, the changes are simple:
- The cause of this bug is in the `reset()` function in the `src/components/app.jsx` file. Previously, it was made to reset the `currentDetails` value to `beginners-wish` in the React state variable (I believe this is the cause of the problem). I fixed the problem by removing the `currentDetails` and adding the `selectedWish` state variable whose value is the current banner that the user is browsing on when he/she clicked the reset button.
- Next, I adjusted the `else` statement in the `src/components/banners.jsx` to not set the `selectedBanner` state variable to `beginners-wish`. That way, when we clicked the reset button, we will still remain in our currently selected banner, not scrolling back to the Beginner's Wish.
- I haven't updated the version number yet, just in case.

I have tested it in [my web server](https://genshin-gacha.nicholasdw.com/) (this includes last PR (#16) changes), and it works like a charm! No more switching to the beginner's wish if we rolled after clicking the reset button!

Don't forget to re-run `npm run build` after merging my previous and this PR, because I made this PR based on your `master` branch, not my `cache-busting-improvements` branch 😅.

I think that's all. Hope it helps and thank you!

Resolves #17 