### PR TITLE
Banner layout fix, and enhancement to the mobile UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genshin-impact-wish-simulator",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A React.js web application to simulate Genshin Impact gacha in the browser",
   "main": "index.js",
   "scripts": {

--- a/src/components/banners.jsx
+++ b/src/components/banners.jsx
@@ -128,10 +128,8 @@ export default class Banners extends Component {
           >
           {
             bannerKeys.map(banner => {
-             return (
-                <div key={banner}>
-                  <img src={banners(`./${banner}.png`).default} />
-                </div>
+              return (
+                <img key={banner} className="carousel-image" src={banners(`./${banner}.png`).default} />
               )
             })
           }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -37,11 +37,11 @@ video {
 }
 .wrapper.banners > .heading > .current-banner {
   color: #d4bc8f;
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   text-shadow: 3px 2px 2px rgb(50, 50, 50);
-  width: 200px;
-  margin-left: 1.2rem;
+  width: 250px;
   text-align: center;
+  font-weight: 600;
 }
 .wrapper.banners > .heading > .close-window, .close-button {
   background-size: cover;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -366,9 +366,9 @@ td {
 }
 
 /* For large-width, small-height screens */
-@media (min-height: 800px) and (max-height: 1200px) {
+@media (max-height: 800px) and (max-height: 1000px) {
   .carousel-container {
-    width: 30vw;
+    width: 45vw;
     min-height: 60vh;
     margin: 0 auto;
   }
@@ -378,9 +378,6 @@ td {
   .banner-button {
     height: 81px;
     width: 162px;
-  }
-  .carousel-container {
-    margin: 2rem;
   }
 }
 @media (max-width: 992px) {
@@ -425,7 +422,23 @@ td {
     flex-direction: column;
     margin-bottom: 1rem;
   }
+  .button-container {
+    display: flex;
+    flex-direction: column;
+    font-size: 11px;
+    margin-top: -20px;
+  }
+  .button-container > button {
+    margin: 0;
+    width: 100px;
+  }
+  .button-container > button:last-of-type {
+    margin-top: 2px;
+  }
+  .action-container {
+    margin-top: -10px;
+  }
   .wish-button {
-    width:  123px;
+    width: 115px;
   }
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -365,6 +365,15 @@ td {
   }
 }
 
+/* For large-width, small-height screens */
+@media (min-height: 800px) and (max-height: 1200px) {
+  .carousel-container {
+    width: 30vw;
+    min-height: 60vh;
+    margin: 0 auto;
+  }
+}
+
 @media (max-width: 1200px) {
   .banner-button {
     height: 81px;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -106,8 +106,9 @@ video {
 }
 .carousel-container {
   position: relative;
-  height: 65vh;
-  margin: 2rem 15rem;
+  height: 75vh;
+  width: 65vw;
+  margin: 0 auto;
 }
 .carousel.carousel-slider {
   display: flex;
@@ -340,37 +341,50 @@ td {
 }
 
 /* 4K screen in Chrome DevTools. */
-@media (max-width: 3840px) and (min-width: 2550px) {
+@media (max-width: 4000px) {
   .carousel-container {
-    width: 50vw;
-    min-height: 75vh;
-    margin: 0 auto;
+    width: 30vw;
   }
 }
 
-@media (max-width: 2549px) and (min-width: 2030px) {
+@media (max-width: 2560px) {
   .carousel-container {
-    width: 60vw;
-    min-height: 75vh;
-    margin: 0 auto;
+    width: 40vw;
   }
 }
 
 /* To get a better resolution in a smaller screen (1440px) */
-@media (max-width: 2029px) and (min-width: 1441px) {
+@media (max-width: 2100px) {
   .carousel-container {
-    width: 65vw;
-    min-height: 75vh;
-    margin: 0 auto;
+    width: 50vw;
   }
 }
 
-/* For large-width, small-height screens */
-@media (max-height: 800px) and (max-height: 1000px) {
+/* Ordinary laptop screens */
+@media (max-width: 1600px) {
   .carousel-container {
-    width: 45vw;
-    min-height: 60vh;
-    margin: 0 auto;
+    width: 60vw;
+  }
+}
+
+/* iPad Pro */
+@media (max-height: 1400px) and (max-width: 1024px) {
+  .carousel-container {
+    width: 80vw;
+  }
+}
+
+/* High resolution phones (iPhone X) */
+@media (max-height: 1025px) and (max-width: 1024px) {
+  .carousel-container {
+    width: 85vw;
+  }
+}
+
+/* For small-height screens */
+@media (max-height: 800px) and (max-width: 1024px) {
+  .carousel-container {
+    width: 95vw;
   }
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -115,6 +115,10 @@ video {
 .carousel {
   height: 100%;
 }
+.carousel-image {
+  max-width: 100%;
+  max-height: 100%;
+}
 .action-container {
   height: 10vh;
   display: flex;
@@ -333,6 +337,32 @@ td {
 }
 .mw-50 {
   max-width: 50% !important;
+}
+
+/* 4K screen in Chrome DevTools. */
+@media (max-width: 3840px) and (min-width: 2550px) {
+  .carousel-container {
+    width: 50vw;
+    min-height: 75vh;
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 2549px) and (min-width: 2030px) {
+  .carousel-container {
+    width: 60vw;
+    min-height: 75vh;
+    margin: 0 auto;
+  }
+}
+
+/* To get a better resolution in a smaller screen (1440px) */
+@media (max-width: 2029px) and (min-width: 1441px) {
+  .carousel-container {
+    width: 65vw;
+    min-height: 75vh;
+    margin: 0 auto;
+  }
 }
 
 @media (max-width: 1200px) {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -402,11 +402,15 @@ td {
     height: 50px;
     width: 100px;
   }
+  .heading {
+    flex-direction: column;
+    justify-content: center;
+  }
   .wrapper.banners > .heading > .current-banner {
-    font-size: 1rem;
-    width: 100px;
-    margin-left: 1.2rem;
-    text-align: center;
+    font-size: 1.8rem;
+    width: 100%;
+    margin-top: 10px;
+    align-self: center;
   }
   .wish-container {
     flex-direction: column;


### PR DESCRIPTION
## Problem
From issue #26, we know when using large screens, the banner will overflow like the image below (tested on Chrome DevTools's 4K size):
<img width="960" alt="Capture5" src="https://user-images.githubusercontent.com/31909304/99045252-a01c6d00-25c3-11eb-8b56-0781a89d193a.PNG">

## Cause
After looking at the code, I believe the reason this is happening is because the image tries to 'fit itself' into the `div` container in the best possible way, which is currently impossible because of its aspect ratio. To overcome this, I use `@media` queries in the CSS to adjust several attributes that belongs to the `carousel-container` class when the user's screen is big enough. The attributes are `width`, `min-height`, and `margin`. By doing this, the image should scale appropriately with the user's device, even on large screens.

## Fix
Screenshots of the new layout (I use Google Chrome's DevTools to test them):
![Capture](https://user-images.githubusercontent.com/31909304/99045956-aa8b3680-25c4-11eb-9610-68a55ca36384.PNG)
This is the new layout, tested with 2560 * 1023 (4K) resolution.

![Capture1](https://user-images.githubusercontent.com/31909304/99045705-57b17f00-25c4-11eb-8e12-6e9c5c33cb83.PNG)
This is the new layout, tested with 2000 * 1023 (custom) resolution.

![Capture2](https://user-images.githubusercontent.com/31909304/99045720-5da76000-25c4-11eb-94f6-fc7a71e218b2.PNG)
This is the new layout, tested with 1440 * 1023 (Laptop L) resolution.

## Extra: Small Screen Enhancement for the 'Wish Type' Text
As an extra, I also enhanced the UI for phones with small screens. I believe it is better if location for the 'wish type' text (`Novice Wish`, `Character Event Wish`, etcetera) is at the top of the screen, rather than the left of the banner icons, as it gives more readability. I also added `font-weight` and enhanced the `font-size` to make it easier to see. This is only for phones with small screens though. Any devices other than phones such as tablets, PC, laptop, large screen phones (does it even exist? 😅), etcetera will still have the text on the left of the banner icons.

Previously, the layout was like the following picture:
![image](https://user-images.githubusercontent.com/31909304/99046303-24232480-25c5-11eb-97b3-f5644480a219.png)

I enhanced it to be the following:
![Capture4](https://user-images.githubusercontent.com/31909304/99045748-65ff9b00-25c4-11eb-91ed-0396fa30d3b2.PNG)
This is the new mobile-friendly layout, tested with 375 * 870 (Mobile L) resolution.

![Capture3](https://user-images.githubusercontent.com/31909304/99045739-6304aa80-25c4-11eb-8d16-1d149a4cb36b.PNG)
This is the new mobile-friendly layout, tested with 768 * 1024 (Tablet) resolution. As you can see, the 'wish type' text is still located at the left of the banner icons. This is intentional.

## Closing
Hope this PR will be useful to you, and thank you dude! Oh, and don't forget to rebuild or else the CSS won't update 😅.
Resolves #26 