### PR TITLE
Removed Sacrificial Greatsword from featured normal banner

### DIFF
--- a/src/data/wanderlust-invocation.json
+++ b/src/data/wanderlust-invocation.json
@@ -303,7 +303,6 @@
     "rating": 4,
     "type": "weapon",
     "class": "Sword",
-    "isFeatured": true,
     "src": "sacrificial-greatsword.png"
   },
   {


### PR DESCRIPTION
Sacrificial Greatsword is mis-labeled as a featured item in the normal banner.
(second instance: I don't understand git but I hope I'm doing it right)