### PR TITLE
Probability balancing between characters and weapons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genshin-impact-wish-simulator",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A React.js web application to simulate Genshin Impact gacha in the browser",
   "main": "index.js",
   "scripts": {

--- a/src/data/gentry-of-hermitage.json
+++ b/src/data/gentry-of-hermitage.json
@@ -227,7 +227,6 @@
     "rating": 4,
     "type": "weapon",
     "class": "Sword",
-    "isFeatured": true,
     "src": "sacrificial-greatsword.png"
   },
   {

--- a/src/data/wanderlust-invocation.json
+++ b/src/data/wanderlust-invocation.json
@@ -303,7 +303,6 @@
     "rating": 4,
     "type": "weapon",
     "class": "Sword",
-    "isFeatured": true,
     "src": "sacrificial-greatsword.png"
   },
   {

--- a/src/models/epitome-invocation.js
+++ b/src/models/epitome-invocation.js
@@ -55,6 +55,17 @@ export default class EpitomeInvocation extends BaseGacha {
   getRandomItem(rating) {
     const itemsList = this.getDrops(rating)
     const item = itemsList[this.generateRandomNumber(itemsList.length)]
+    
+    if (rating === 4) {
+      const isCharacter = this.flipACoin();
+
+      if (isCharacter) {
+        return this.getRandom4StarCharacters();
+      }
+
+      return this.getRandom4StarWeapons();
+    }
+
     return item
   }
   getGuaranteed5StarItem() {
@@ -100,5 +111,15 @@ export default class EpitomeInvocation extends BaseGacha {
     const items = this.getDrops(rating)
     const featuredItems = items.filter(item => item.rating === rating && item.isFeatured === true)
     return featuredItems[this.generateRandomNumber(featuredItems.length)]
+  }
+  getRandom4StarCharacters() {
+    const items = this.getDrops(4);
+    const characters = items.filter(item => item.rating === 4 && item.type === 'character');
+    return characters[this.generateRandomNumber(characters.length)];
+  }
+  getRandom4StarWeapons() {
+    const items = this.getDrops(4);
+    const weapons = items.filter(item => item.rating === 4 && item.type === 'weapon');
+    return weapons[this.generateRandomNumber(weapons.length)];
   }
 }

--- a/src/models/gentry-of-hermitage.js
+++ b/src/models/gentry-of-hermitage.js
@@ -48,13 +48,22 @@ export default class GentryOfHermitage extends BaseGacha {
   }
   getRandomItem(rating) {
     const itemsList = this.getDrops(rating);
-    let item;
 
     if (this.guaranteedZhongli && rating === 5) {
       return this.grabAZhongli();
-    } else {
-      item = itemsList[this.generateRandomNumber(itemsList.length)];
     }
+
+    if (rating === 4) {
+      const isCharacter = this.flipACoin();
+
+      if (isCharacter) {
+        return this.getRandom4StarCharacters();
+      }
+
+      return this.getRandom4StarWeapons();
+    }
+
+    const item = itemsList[this.generateRandomNumber(itemsList.length)];
 
     if (item.rating === 5 && item.name !== 'Zhongli') {
       this.guaranteedZhongli = true;
@@ -94,5 +103,15 @@ export default class GentryOfHermitage extends BaseGacha {
   grabAZhongli() {
     this.guaranteedZhongli = false
     return this.drops.find(item => item.name === 'Zhongli')
+  }
+  getRandom4StarCharacters() {
+    const items = this.getDrops(4);
+    const characters = items.filter(item => item.rating === 4 && item.type === 'character');
+    return characters[this.generateRandomNumber(characters.length)];
+  }
+  getRandom4StarWeapons() {
+    const items = this.getDrops(4);
+    const weapons = items.filter(item => item.rating === 4 && item.type === 'weapon');
+    return weapons[this.generateRandomNumber(weapons.length)];
   }
 }

--- a/src/models/wanderlust-invocation.js
+++ b/src/models/wanderlust-invocation.js
@@ -47,6 +47,17 @@ export default class WanderlustInvocation extends BaseGacha {
   getRandomItem(rating) {
     const itemsList = this.getDrops(rating)
     const item = itemsList[this.generateRandomNumber(itemsList.length)]
+
+    if (rating === 4) {
+      const isCharacter = this.flipACoin();
+
+      if (isCharacter) {
+        return this.getRandom4StarCharacters();
+      }
+
+      return this.getRandom4StarWeapons();
+    }
+
     return item
   }
   getGuaranteed4StarItemOrHigher() {
@@ -56,5 +67,15 @@ export default class WanderlustInvocation extends BaseGacha {
       return this.getRandomItem(5)
     }
       return this.getRandomItem(4)
+  }
+  getRandom4StarCharacters() {
+    const items = this.getDrops(4);
+    const characters = items.filter(item => item.rating === 4 && item.type === 'character');
+    return characters[this.generateRandomNumber(characters.length)];
+  }
+  getRandom4StarWeapons() {
+    const items = this.getDrops(4);
+    const weapons = items.filter(item => item.rating === 4 && item.type === 'weapon');
+    return weapons[this.generateRandomNumber(weapons.length)];
   }
 }


### PR DESCRIPTION
## Problem

What's up dude? Sorry I have not been active lately, kind of busy with final exams! Anyways, from issue #28, we know that our current setup has not yet been implemented with probability balancing between characters and weapons.

## Fix

To fix this issue, I added two new methods, which are `getRandom4StarCharacters` and `getRandom4StarWeapons`. Both function will be called from `getRandomItem` function if we get a 4 star (`rating` is equal to `4`). I also split the probability via the given `flipACoin` function. I have implemented them in the Gentry of Hermitage, the Epitome Invocation, and the Wanderlust Invocation banner.

## Extra

I noticed that you have not updated the `isFeatured` property for Sacrificial Greatsword in the Wanderlust Invocation and the Gentry of Hermitage banner. I fixed it in this PR.

## Closing

Hope this PR will be useful, and thank you dude!

Resolves #28 